### PR TITLE
Fix failing source map tests

### DIFF
--- a/test/sourcemap.coffee
+++ b/test/sourcemap.coffee
@@ -16,9 +16,6 @@ test "encodeVlq tests", ->
   for pair in vlqEncodedValues
     eq ((new SourceMap).encodeVlq pair[0]), pair[1]
 
-eqJson = (a, b) ->
-  eq (JSON.stringify JSON.parse a), (JSON.stringify JSON.parse b)
-
 test "SourceMap tests", ->
   map = new SourceMap
   map.add [0, 0], [0, 0]
@@ -28,11 +25,28 @@ test "SourceMap tests", ->
   map.add [3, 0], [3, 4]
 
   testWithFilenames = map.generate {
-        sourceRoot: "",
-        sourceFiles: ["source.coffee"],
-        generatedFile: "source.js"}
-  eqJson testWithFilenames, '{"version":3,"file":"source.js","sourceRoot":"","sources":["source.coffee"],"names":[],"mappings":"AAAA;;IACK,GAAC,CAAG;IAET"}'
-  eqJson map.generate(), '{"version":3,"file":"","sourceRoot":"","sources":[""],"names":[],"mappings":"AAAA;;IACK,GAAC,CAAG;IAET"}'
+    sourceRoot: ""
+    sourceFiles: ["source.coffee"]
+    generatedFile: "source.js"
+  }
+
+  deepEqual testWithFilenames, {
+    version: 3
+    file: "source.js"
+    sourceRoot: ""
+    sources: ["source.coffee"]
+    names: []
+    mappings: "AAAA;;IACK,GAAC,CAAG;IAET"
+  }
+
+  deepEqual map.generate(), {
+    version: 3
+    file: ""
+    sourceRoot: ""
+    sources: [""]
+    names: []
+    mappings: "AAAA;;IACK,GAAC,CAAG;IAET"
+  }
 
   # Look up a generated column - should get back the original source position.
   arrayEq map.sourceLocation([2,8]), [1,9]


### PR DESCRIPTION
This should have been done in commit 841b3cd2, but I forgot to. Since
that commit, `SourceMap::generate` returns an object instead of
`JSON.stringify()` of that object, but the tests still compared strings.

Fixes #4269.

Note: `SourceMap::generate` is only used internally, so its change in
return type is not a breaking change. The "public API" is unchanged.